### PR TITLE
README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,30 +8,30 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 
   1. Add `mawu` to your list of dependencies in `mix.exs`:
 
-    ```elixir
-    def deps do
-      [{:mawu, "~> 0.1.0"}]
-    end
-    ```
+```elixir
+def deps do
+  [{:mawu, "~> 0.1.0"}]
+end
+```
 
   2. Ensure `mawu` is started before your application:
 
-    ```elixir
-    def application do
-      [applications: [:mawu]]
-    end
-    ```
+```elixir
+def application do
+  [applications: [:mawu]]
+end
+```
 
   3. Add your Google app keys to the `Uberauth` configuration,
   (you can generate one [here](https://console.developers.google.com/)):
 
-    ```elixir
-    config :ueberauth, Ueberauth, providers: [google: {Ueberauth.Strategy.Google, []}]
-    config :ueberauth, Ueberauth.Strategy.Google.OAuth,
-      # Please use env vars (ఠ్ఠ ˓̭ ఠ్ఠ)
-      client_id: System.get_env("GOOGLE_CLIENT_ID"),
-      client_secret: System.get_env("GOOGLE_CLIENT_SECRET")
-    ```
+```elixir
+config :ueberauth, Ueberauth, providers: [google: {Ueberauth.Strategy.Google, []}]
+config :ueberauth, Ueberauth.Strategy.Google.OAuth,
+  # Please use env vars (ఠ్ఠ ˓̭ ఠ్ఠ)
+  client_id: System.get_env("GOOGLE_CLIENT_ID"),
+  client_secret: System.get_env("GOOGLE_CLIENT_SECRET")
+```
 
   4. Check the [Überauth Google readme](https://github.com/ueberauth/ueberauth_google) to implement the Google auth.
 


### PR DESCRIPTION
GitHub syntax highlighting wasn't working because indentation on the code blocks had them being rendered as quotes:

![image](https://user-images.githubusercontent.com/15011718/31656217-41e8f54a-b32b-11e7-9d16-aabef492d192.png)

Updated to:

![image](https://user-images.githubusercontent.com/15011718/31656264-60c24bf6-b32b-11e7-9436-29ff6b2d868e.png)
